### PR TITLE
fix typos in UI5con and ABAPConf names

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,10 +6,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Code Connect 2024</title>
   <meta name="description"
-    content="Join us for 4 consecutive days of groundbreaking conferences and events all under the banner of CodeConnect! Same location, triple the insights, innovation, and networking opportunities." />
+    content="Join us for 4 consecutive days of groundbreaking conferences and events all under the banner of Code Connect! Same location, triple the insights, innovation, and networking opportunities." />
 
   <meta name="keywords"
-    content="SAP, reCAP, abab, ui5con, Cloud, SAPCAP, OpenUI5, DevOps, SAPUI5, UI5con, UI5 Web Components, Web Components, Webcomponents, Open Source" />
+    content="SAP, reCAP, abab, Cloud, SAPCAP, OpenUI5, DevOps, SAPUI5, UI5con, UI5 Web Components, Web Components, Webcomponents, Open Source" />
 
   <meta property="twitter:card" content="summary" />
 
@@ -40,11 +40,11 @@
     <div class="cc-header-banner">
       <span>20</span>
       <img src="./images/code-connect.png"
-         alt="Illustration representing the Code Connect conference. Contains logos of ui5con, reCAP and abap conference." />
+         alt="Illustration representing the Code Connect conference. Contains logos of UI5con, reCAP and abap conference." />
       <span>24</span>
     </div>
 
-    <p>Join us for 4 consecutive days of groundbreaking conferences and events all under the banner of CodeConnect! Same location, triple the insights, innovation, and networking opportunities. <br>Save the dates and stay tuned for further details!</p>
+    <p>Join us for 4 consecutive days of groundbreaking conferences and events all under the banner of Code Connect! Same location, triple the insights, innovation, and networking opportunities. <br>Save the dates and stay tuned for further details!</p>
   </header>
   <main>
     <section>
@@ -80,11 +80,11 @@
           <span>05</span>
         </div>
         <div class="cc-teaser-content">
-          <h2>UI5Con</h2>
+          <h2>UI5con</h2>
           <p>If you want to learn more about UI5, you can't miss UI5con 2024. A day of inspiration, learning, and networking
             with like-minded people. Inspiring talks. Endless learning.</p>
           <a href="https://openui5.org/ui5con/germany2024/" target="_blank" hreflang="en" rel="noopener noreferrer"
-             title="Click to open UI5Con conf website. Opens in a new window.">learn more</a>
+             title="Click to open UI5con conf website. Opens in a new window.">learn more</a>
         </div>
       </div>
 
@@ -94,7 +94,7 @@
           <span>06</span>
         </div>
         <div class="cc-teaser-content">
-          <h2>ABAPconf 2024 Europe</h2>
+          <h2>ABAPConf 2024 Europe</h2>
           <p>The conference for ABAP developers, from ABAP developers. ABAP as we love it. Changing the deployment model,
             ABAPConf leaves the cloud and is now also offered as an on-premise edition.</p>
           <a href="https://abapconf.org/" target="_blank" hreflang="en" rel="noopener noreferrer"


### PR DESCRIPTION
Fixed the following typos:
- name of UI5con
- name of ABAPConf
- space between CodeConnect
- removed duplicated keyword in the meta tag